### PR TITLE
Updates minimum Omniauth dependency to 1.9.0 for additional security updates

### DIFF
--- a/omniauth-ldap.gemspec
+++ b/omniauth-ldap.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/intridea/omniauth-ldap"
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency     'omniauth', '~> 1.8.1'
+  gem.add_runtime_dependency     'omniauth', '~> 1.9'
   gem.add_runtime_dependency     'net-ldap', '~> 0.16'
   gem.add_runtime_dependency     'pyu-ruby-sasl', '~> 0.0.3.3'
   gem.add_runtime_dependency     'rubyntlm', '~> 0.6.2'


### PR DESCRIPTION
To solve dependencies with another omniauth plugin, such like omniauth-oauth2 v1.6 (omniauth/omniauth-oauth2@471c0b0cb06ca7c892c0632d41840a9f93e104bf)
